### PR TITLE
Merging 1.1.1 version from the develop-branch to the main

### DIFF
--- a/LRU_cache.hpp
+++ b/LRU_cache.hpp
@@ -22,7 +22,10 @@ namespace gtd {
     template <typename rT, typename... argTs>
     class LRU_cache {
     public:
+        /// @param _ptr the function pointer.
         explicit LRU_cache(rT(*_ptr)(argTs...)) : __func_ptr{_ptr} {}
+        /// @param _ptr the function pointer.
+        /// @param _size the maximum size of the cache.
         explicit LRU_cache(rT(*_ptr)(argTs...), std::size_t _size) : __func_ptr{_ptr}, __cache_size{_size} {}
         rT operator()(argTs... args) {
             std::tuple<argTs...> tuple_args = std::make_tuple(args...);
@@ -40,18 +43,26 @@ namespace gtd {
                 return _return;
             }
         }
-        std::size_t cache_size() {
+        /// @brief Returns the size of the cache.
+        /// @return Cache size as std::size_t.
+        std::size_t cache_size() const {
             return __cache_map.size();
         }
-        void change_cache_size(std::size_t new_size) {
+        /// @brief Reduces the size of the cache to the specified size.
+        /// @param new_size the new size of the cache as std::size_t.
+        void reduce_cache_size(std::size_t new_size) {
             while(cache_size() > new_size) {
                 __cache_map.erase(__cache.back().first);
                 __cache.pop_back();
             }
         }
-        std::size_t cache_capacity() {
+        /// @brief Returns the maximum size of the cache.
+        /// @return Maximum cache size as std::size_t (0 - if an infinity size).
+        std::size_t cache_capacity() const {
             return __cache_size;
         }
+        /// @brief Changes the maximum size of the cache to the specified size.
+        /// @param new_size the new maximum size of the cache as std::size_t (0 - to an infinity size).
         void change_cache_capacity(std::size_t new_size) {
             if((__cache_size > new_size || __cache_size == 0) && new_size != 0) {
                 while(cache_size() > new_size) {
@@ -61,13 +72,18 @@ namespace gtd {
             }
             __cache_size = new_size;
         }
+        /// @brief Clear the all cache.
         void clear_cache() {
             __cache_map.clear();
             __cache.clear();
         }
+        /// @brief Clear the cache's entry with the specified arguments.
+        /// @param args... the set of the function's arguments.
         void clear_cache(argTs... args) {
             clear_cache(std::make_tuple(args...));
         }
+        /// @brief Clear the cache's entry with the specified arguments.
+        /// @param args the set of the function's arguments as std::tuple.
         void clear_cache(std::tuple<argTs...> args) {
             if(__cache_map.count(args) == 0) return;
             __cache.erase(__cache_map[args]);

--- a/LRU_cache.hpp
+++ b/LRU_cache.hpp
@@ -45,7 +45,7 @@ namespace gtd {
         }
         void change_cache_size(std::size_t new_size) {
             if(new_size >= cache_size()) return;
-            for(unsigned long long int i{}; i < cache_size()-new_size; ++i) {
+            while(cache_size() > new_size) {
                 __cache_map.erase(__cache.back().first);
                 __cache.pop_back();
             }
@@ -54,8 +54,8 @@ namespace gtd {
             return __cache_size;
         }
         void change_cache_capacity(std::size_t new_size) {
-            if(__cache_size > new_size && new_size != 0) {
-                for(unsigned long long int i{}; i < __cache_size-new_size; ++i) {
+            if((__cache_size > new_size || __cache_size == 0) && new_size != 0) {
+                while(cache_size() > new_size) {
                     __cache_map.erase(__cache.back().first);
                     __cache.pop_back();
                 }

--- a/LRU_cache.hpp
+++ b/LRU_cache.hpp
@@ -12,7 +12,7 @@ namespace std {
     public:
         std::size_t operator()(const std::tuple<Ts...>& _tuple) const {
             return std::apply([](const Ts&... args) { 
-                return (... ^ std::hash<std::decay_t<Ts>>{}(args));
+                return (00 ^ ... ^ std::hash<std::decay_t<Ts>>{}(args));
             }, _tuple);
         }
     };

--- a/LRU_cache.hpp
+++ b/LRU_cache.hpp
@@ -22,28 +22,61 @@ namespace gtd {
     template <typename rT, typename... argTs>
     class LRU_cache {
     public:
-        explicit LRU_cache(rT(*_ptr)(argTs...)) : func_ptr{_ptr} {}
-        explicit LRU_cache(rT(*_ptr)(argTs...), std::size_t _size) : func_ptr{_ptr}, cache_size{_size} {}
+        explicit LRU_cache(rT(*_ptr)(argTs...)) : __func_ptr{_ptr} {}
+        explicit LRU_cache(rT(*_ptr)(argTs...), std::size_t _size) : __func_ptr{_ptr}, __cache_size{_size} {}
         rT operator()(argTs... args) {
             std::tuple<argTs...> tuple_args = std::make_tuple(args...);
-            if(cache_map.count(tuple_args)) {
-                cache.splice(cache.begin(),cache,cache_map[tuple_args]);
-                return cache_map[tuple_args]->second;
+            if(__cache_map.count(tuple_args)) {
+                __cache.splice(__cache.begin(),__cache,__cache_map[tuple_args]);
+                return __cache_map[tuple_args]->second;
             } else {
-                if(cache_size != 0ull) { if(cache_map.size() == cache_size) {
-                    cache_map.erase(cache.back().first);
-                    cache.pop_back();
+                if(__cache_size != 0ull) { if(__cache_map.size() == __cache_size) {
+                    __cache_map.erase(__cache.back().first);
+                    __cache.pop_back();
                 } }
-                rT _return = func_ptr(args...);
-                cache.push_front({tuple_args,_return});
-                cache_map[tuple_args] = cache.begin();
+                rT _return = __func_ptr(args...);
+                __cache.push_front({tuple_args,_return});
+                __cache_map[tuple_args] = __cache.begin();
                 return _return;
             }
         }
+        std::size_t cache_size() {
+            return __cache_map.size();
+        }
+        void change_cache_size(std::size_t new_size) {
+            if(new_size >= cache_size()) return;
+            for(unsigned long long int i{}; i < cache_size()-new_size; ++i) {
+                __cache_map.erase(__cache.back().first);
+                __cache.pop_back();
+            }
+        }
+        std::size_t cache_capacity() {
+            return __cache_size;
+        }
+        void change_cache_capacity(std::size_t new_size) {
+            if(__cache_size > new_size && new_size != 0) {
+                for(unsigned long long int i{}; i < __cache_size-new_size; ++i) {
+                    __cache_map.erase(__cache.back().first);
+                    __cache.pop_back();
+                }
+            }
+            __cache_size = new_size;
+        }
+        void clear_cache() {
+            __cache_map.clear();
+            __cache.clear();
+        }
+        void clear_cache(argTs... args) {
+            clear_cache(std::make_tuple(args...));
+        }
+        void clear_cache(std::tuple<argTs...> args) {
+            __cache.erase(__cache_map[args]);
+            __cache_map.erase(args);
+        }
     private:
-        rT(*func_ptr)(argTs...){};
-        std::size_t cache_size{};
-        std::list<std::pair<std::tuple<argTs...>,rT>> cache{};
-        std::unordered_map<std::tuple<argTs...>, typename std::list<std::pair<std::tuple<argTs...>,rT>>::iterator> cache_map{};
+        rT(*__func_ptr)(argTs...){};
+        std::size_t __cache_size{};
+        std::list<std::pair<std::tuple<argTs...>,rT>> __cache{};
+        std::unordered_map<std::tuple<argTs...>, typename std::list<std::pair<std::tuple<argTs...>,rT>>::iterator> __cache_map{};
     };
 }

--- a/LRU_cache.hpp
+++ b/LRU_cache.hpp
@@ -44,7 +44,6 @@ namespace gtd {
             return __cache_map.size();
         }
         void change_cache_size(std::size_t new_size) {
-            if(new_size >= cache_size()) return;
             while(cache_size() > new_size) {
                 __cache_map.erase(__cache.back().first);
                 __cache.pop_back();
@@ -70,6 +69,7 @@ namespace gtd {
             clear_cache(std::make_tuple(args...));
         }
         void clear_cache(std::tuple<argTs...> args) {
+            if(__cache_map.count(args) == 0) return;
             __cache.erase(__cache_map[args]);
             __cache_map.erase(args);
         }

--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ int main() {
 
 <img src="Tests and examples\lru_test.gif" alt="LRU_cache demonstration" width="100%">
 
-This code has a simple long-computing function (it just sleeps for two seconds before returning std::pow). This function are sent to `lru_func`'s constructor with `std::size_t` value of two. First three calls are computed for two seconds because they have unique sets of arguments. Cache has only two entries so this object saves only last two calls. That's because the 4th and 5th calls return their values instantly but 6th one are computed for two seconds again.
+This code has a simple long-computing function (it just sleeps for two seconds before returning std::pow). This function are sent to `lru_func`'s constructor with `std::size_t` value of two. First three calls are computed for two seconds because they have unique sets of arguments. Cache can have only two entries so this object saves only last two calls. That's because the 4th and 5th calls return their values instantly but 6th one are computed for two seconds again.
 
 > [!WARNING]
 > The type of each argument must be hashable via `std::hash`. Override `std::hash` if your function takes an object of a class as an argument.
 
 **Cache management methods:**<br>
-.cache_size() - returns the size of the cache as `std::size_t` (number of saved entries)<br>
+.cache_size() - returns the size of the cache as `std::size_t`<br>
 .reduce_cache_size(_std::size_t_) - reduces the size of the cache to the specified size<br>
 .cache_capacity() - returns the current maximum size of the cache as `std::size_t` (0 - if an infinity size)<br>
 .change_cache_capacity(_std::size_t_) - changes the maximum size of the cache to the specified size (0 - to an infinity size)<br>

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ This code has a simple long-computing function (it just sleeps for two seconds b
 .cache_capacity() - returns the current maximum size of the cache as `std::size_t` (0 - if an infinity size)<br>
 .change_cache_capacity(_std::size_t_) - changes the maximum size of the cache to the specified size (0 - to an infinity size)<br>
 .clear_cache() - clear the all cache<br>
-.clear_cache(argTs...) - clear the cache's entry with the specified arguments<br>
-.clear_cache(std::tuple<argTs...>) - clear the cache's entry with the specified arguments<br>
+.clear_cache(_argTs..._) - clear the cache's entry with the specified arguments<br>
+.clear_cache(_std::tuple<argTs...>_) - clear the cache's entry with the specified arguments<br>
 
 # Versions
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Decorator Library is my C++ library for creating various function decorators. It
 > [!NOTE]
 > All library classes are in `gtd::` namespace.
 
+## Creating simple decorator
+
 Decorator is a class which constuctor takes a _function pointer_ and saves it. The resulting object is callable and takes the same arguments' types.<br>
 The library provides you with a `gtd::Decorator` base-class. To create your own decorator you should create an inherited class and override its _call operator_.
 
@@ -75,7 +77,7 @@ This code shows you HelloDecorator class that can take any function and writes h
 
 ## LRU_cache
 
-The library provides you with a `gtd::LRU_cache` class. Its consturctor takes a _function pointer_ and creates a callable function object. This object saves returned value for each first call with unique set of arguments. The constuctor can also takes a second argument with `std::size_t` type - size of cache (number of cells).
+The library provides you with a `gtd::LRU_cache` class. Its consturctor takes a _function pointer_ and creates a callable function object. This object saves returned value for each first call with unique set of arguments. The constuctor can also takes a second argument with `std::size_t` type - size of cache (number of entries).
 
 ```cpp
 #include <iostream>
@@ -104,17 +106,27 @@ int main() {
 
 <img src="Tests and examples\lru_test.gif" alt="LRU_cache demonstration" width="100%">
 
-This code has a simple long-computing function (it just sleeps for two seconds before returning std::pow). This function are sent to `lru_func`'s constructor with `std::size_t` value of two. First three calls are computed for two seconds because they have unique sets of arguments. Cache has only two cells so this object saves only last two calls. That's because the 4th and 5th calls return their values instantly but 6th one are computed for two seconds again.
+This code has a simple long-computing function (it just sleeps for two seconds before returning std::pow). This function are sent to `lru_func`'s constructor with `std::size_t` value of two. First three calls are computed for two seconds because they have unique sets of arguments. Cache has only two entries so this object saves only last two calls. That's because the 4th and 5th calls return their values instantly but 6th one are computed for two seconds again.
 
 > [!WARNING]
 > The type of each argument must be hashable via `std::hash`. Override `std::hash` if your function takes an object of a class as an argument.
 
+**Cache management methods:**<br>
+.cache_size() - returns the size of the cache as `std::size_t` (number of saved entries)<br>
+.reduce_cache_size(_std::size_t_) - reduces the size of the cache to the specified size<br>
+.cache_capacity() - returns the current maximum size of the cache as `std::size_t` (0 - if an infinity size)<br>
+.change_cache_capacity(_std::size_t_) - changes the maximum size of the cache to the specified size (0 - to an infinity size)<br>
+.clear_cache() - clear the all cache<br>
+.clear_cache(argTs...) - clear the cache's entry with the specified arguments<br>
+.clear_cache(std::tuple<argTs...>) - clear the cache's entry with the specified arguments<br>
+
 # Versions
 
-**Current version: 1.1.0**
+**Current version: 1.1.1**
 
 + 1.x.x
   + 1.1.x
+    + 1.1.1 - LRU_cache's cache management methods added
     + 1.1.0 - LRU_cache added
   + 1.0.x
     + 1.0.0 - base functional of Decorator base-class


### PR DESCRIPTION
# About 1.1.1 version
This library version provides you with updated LRU_cache decorator
### Fixes
LRU_cache - added ability to use it with no-argument functions
### Improvements
LRU_cache - added essential cache management methods<br>
.cache_size() - returns the size of the cache as `std::size_t` (number of saved entries)
.reduce_cache_size(_std::size_t_) - reduces the size of the cache to the specified size
.cache_capacity() - returns the current maximum size of the cache as `std::size_t` (0 - if an infinity size)
.change_cache_capacity(_std::size_t_) - changes the maximum size of the cache to the specified size (0 - to an infinity size)
.clear_cache() - clear the all cache
.clear_cache(argTs...) - clear the cache's entry with the specified arguments
.clear_cache(std::tuple<argTs...>) - clear the cache's entry with the specified arguments<br>
LRU_cache - added Doxygen comments